### PR TITLE
concatenates data frames along the correct axis.

### DIFF
--- a/fex/collection.py
+++ b/fex/collection.py
@@ -55,4 +55,4 @@ class Collection(object):
             with open(self.cache_path, 'wb') as f:
                 pickle.dump(self._cache, f)
 
-        return pd.concat(results)
+        return pd.concat(results, axis=1, join='outer')


### PR DESCRIPTION
we want to keep the indices and concat along columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/fex/15)
<!-- Reviewable:end -->
