### PR TITLE
Fixed argument splitting and process invocation

### DIFF
--- a/fex/runner.py
+++ b/fex/runner.py
@@ -18,9 +18,7 @@ def _run_cmd_get_output(cmd):
 
     Mimics python3's subprocess.getoutput
     """
-    process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE)
-    out, err = process.communicate()
-    return out or err
+    return subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
 
 
 def _remote_github_url_to_string(remote_url):

--- a/fex/runner.py
+++ b/fex/runner.py
@@ -51,9 +51,14 @@ def _git_is_pristine():
     raises: `EnvironmentError` if current directory is not a git repository.
     """
     command = 'git diff HEAD --shortstat'
-    diff_str = _run_cmd_get_output(command)
-    if "error: Could not access 'HEAD'" in diff_str:
-        raise EnvironmentError('Not a git repository.')
+    try:
+        diff_str = _run_cmd_get_output(command)
+    except subprocess.CalledProcessError as e:
+        if "error: Could not access 'HEAD'" in e.output:
+            raise EnvironmentError('Not a git repository.')
+        else:
+            raise
+
     return diff_str == ''
 
 

--- a/fex/runner.py
+++ b/fex/runner.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -17,7 +18,7 @@ def _run_cmd_get_output(cmd):
 
     Mimics python3's subprocess.getoutput
     """
-    process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+    process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE)
     out, err = process.communicate()
     return out or err
 


### PR DESCRIPTION
The main change here is switching from ```subprocess.Popen``` to ```subprocess.check_output```. Other parts of the module are expecting to receive a subprocess.CalledProcessError if an error condition is returned by the command executed in ```_run_cmd_get_output```, which may be raised by ```subprocess.check_output``` but not ```subprocess.Popen```. The ```_git_is_pristine``` function checks the output to determine whether the command was invoked from a git repo or not, so I have piped stderr to stdout so that the error can be accessed from the exception object.

The other change is to use ```shlex``` for argument splitting. It is more robust than just using the string split function, and handles things like quoted strings for example. 